### PR TITLE
詳細ページと編集ページを行き来できるようにする #13

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -4,6 +4,7 @@ import { BrowserRouter, Route } from 'react-router-dom';
 // screens
 import List from './list/List';
 import Detail from './detail/Detail';
+import Edit from './edit/Edit';
 
 const Routes = () => {
   return (
@@ -11,6 +12,7 @@ const Routes = () => {
       <div>
         <Route path="/" exact component={List} />
         <Route path="/detail" component={Detail} />
+        <Route path="/edit" component={Edit} />
       </div>
     </BrowserRouter>
   );

--- a/src/detail/Detail.js
+++ b/src/detail/Detail.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 class Detail extends React.Component {
   contents = {
@@ -20,12 +21,8 @@ class Detail extends React.Component {
             <td>{this.contents.body}</td>
           </tr>
         </table>
-        <button type="button">
-          削除
-        </button>
-        <button type="button">
-          編集
-        </button>
+        <button type="button">削除</button>
+        <Link to="/edit"><button type="button">編集</button></Link>
       </>
     );
   }

--- a/src/edit/Edit.js
+++ b/src/edit/Edit.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 class Edit extends React.Component {
   contents = {
@@ -20,9 +21,7 @@ class Edit extends React.Component {
             <td><textarea>{this.contents.body}</textarea></td>
           </tr>
         </table>
-        <button type="button">
-          保存
-        </button>
+        <Link to="/detail"><button type="button">保存</button></Link>
       </>
     );
   }


### PR DESCRIPTION
詳細画面の編集を押すと編集ページに画面遷移し、編集画面の保存を押すと詳細画面に戻るように遷移しました