### PR TITLE
feat: ビルド時にGithub Secretから環境変数を受け取るようにする

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,14 @@ jobs:
         run: |
           npm ci
           npm run build
+        env:
+          REACT_APP_API_KEY: ${{secrets.REACT_APP_API_KEY}}
+          REACT_APP_APP_ID: ${{secrets.REACT_APP_APP_ID}}
+          REACT_APP_ENVIRONMENT: ${{secrets.REACT_APP_ENVIRONMENT}}
+          REACT_APP_MEASUREMENT_ID: ${{secrets.REACT_APP_MEASUREMENT_ID}}
+          REACT_APP_MESSAGING_SENDER_ID: ${{secrets.REACT_APP_MESSAGING_SENDER_ID}}
+          REACT_APP_PROJECT_ID: ${{secrets.REACT_APP_PROJECT_ID}}
+
 
       - name: deproy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Github Secretsに登録した環境変数をGithub pagesで受け取るための設定

Github Actionのビルド時にenvにセットしてあげれば多分行けるんじゃないかなぁ


多分参考：https://btj0.com/blog/github/use-env/